### PR TITLE
pull request for default value set in-properly in wmessage

### DIFF
--- a/src/wmessage.c
+++ b/src/wmessage.c
@@ -141,17 +141,7 @@ pbc_wmessage_integer(struct pbc_wmessage *m, const char *key, uint32_t low, uint
 		_packed_integer(m , f, key , low, hi);
 		return 0;		
 	}
-	if (f->label == LABEL_OPTIONAL) {
-		if (f->type == PTYPE_ENUM) {
-			if (low == f->default_v->e.id)
-				return 0;
-		} else {
-			if (low == f->default_v->integer.low &&
-				hi == f->default_v->integer.hi) {
-				return 0;
-			}
-		}
-	}
+
 	int id = f->id << 3;
 
 	_expand(m,20);
@@ -212,10 +202,6 @@ pbc_wmessage_real(struct pbc_wmessage *m, const char *key, double v) {
 		return 0;		
 	}
 
-	if (f->label == LABEL_OPTIONAL) {
-		if (v == f->default_v->real)
-			return 0;
-	}
 	int id = f->id << 3;
 	_expand(m,18);
 	switch (f->type) {
@@ -273,18 +259,6 @@ pbc_wmessage_string(struct pbc_wmessage *m, const char *key, const char * v, int
 		return 0;	
 	}
 
-	if (f->label == LABEL_OPTIONAL) {
-		if (f->type == PTYPE_ENUM) {
-			if (strncmp(v , f->default_v->e.name, len) == 0 && f->default_v->e.name[len] =='\0') {
-				return 0;
-			}
-		} else if (f->type == PTYPE_STRING) {
-			if (len == f->default_v->s.len &&
-				strcmp(v, f->default_v->s.str) == 0) {
-				return 0;
-			}
-		}
-	}
 	int id = f->id << 3;
 	_expand(m,20);
 	switch (f->type) {


### PR DESCRIPTION
Hi 云风,
## 很感谢你提供了一个这样好的library，我觉得这个是我见过最好的一个pb-c-client, 不过我在使用中发现了一个问题: 当我们为wmessage set一些值的时候，目前的逻辑是，如果key==optional && value==default_value, 程序会直接return, 我能理解这个优化，但是在这种直接return的情况下，官方pb library将buffer反序列化后，调用has-field-name的时候，会返回false，从而会影响程序的正确性。我目前在实现一个Hadoop-YARN的PB-C client中就遇到了这样的问题，

非常感谢
Wangda
