### PR TITLE
fix core dump crash

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -383,6 +383,9 @@ _pbcM_sp_query(struct map_sp *map, const char *key)
 
 	struct _pbcM_sp_slot * slot = &map->slot[hash];
 	for (;;) {
+		if (!slot->key) {
+			return NULL;
+		}
 		if (slot->hash == hash_full && strcmp(slot->key, key) == 0) {
 			return slot->pointer;
 		}


### PR DESCRIPTION
修复strcmp一个参数为空指针从而导致crash的严重bug。

**但我不确定这样修改是否正确**：
请问云大slot的key为NULL的时候，是否还需要继续循环比较其他slot？

如果不需要，就直接合并吧