### PR TITLE
assemble LuaJIT's executable name automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,23 @@ env:
         - LJ_REPO="https://github.com/LuaJIT/LuaJIT.git"
         - INC_DIR=/usr/local/include
     matrix:
-        - LUA=lua-5.1    LUA_TYPE=lua    LUA_BIN=lua     LUA_DIST=lua-5.1.5      LUA_BD=lua    LUA_INC=$INC_DIR
-        - LUA=lua-5.2    LUA_TYPE=lua    LUA_BIN=lua     LUA_DIST=lua-5.2.4      LUA_BD=lua    LUA_INC=$INC_DIR
-        - LUA=lua-5.3    LUA_TYPE=lua    LUA_BIN=lua     LUA_DIST=lua-5.3.2      LUA_BD=lua53  LUA_INC=$INC_DIR
-        - LUA=luajit-2.0 LUA_TYPE=luajit LUA_BIN=luajit             LJ_BR=master LUA_BD=lua    LUA_INC=$INC_DIR/$LUA
-        - LUA=luajit-2.1 LUA_TYPE=luajit LUA_BIN=luajit-2.1.0-beta2 LJ_BR=v2.1   LUA_BD=lua    LUA_INC=$INC_DIR/$LUA
+        - LUA=lua-5.1    LUA_TYPE=lua    LUA_DIST=lua-5.1.5 LUA_BD=lua   LUA_INC=$INC_DIR
+        - LUA=lua-5.2    LUA_TYPE=lua    LUA_DIST=lua-5.2.4 LUA_BD=lua   LUA_INC=$INC_DIR
+        - LUA=lua-5.3    LUA_TYPE=lua    LUA_DIST=lua-5.3.2 LUA_BD=lua53 LUA_INC=$INC_DIR
+        - LUA=luajit-2.0 LUA_TYPE=luajit LJ_BR=master       LUA_BD=lua   LUA_INC=$INC_DIR/$LUA
+        - LUA=luajit-2.1 LUA_TYPE=luajit LJ_BR=v2.1         LUA_BD=lua   LUA_INC=$INC_DIR/$LUA
 
 before_install:
     - mkdir -p $DEPS_BUILD_DIR
     - sudo apt-get update -qq
     - sudo apt-get install libprotobuf-dev protobuf-compiler
+    - LUA_BIN=lua
 
 install:
     # install Lua/LuaJIT
     - cd $DEPS_BUILD_DIR
     - if [ "$LUA_TYPE" == "luajit" ]; then
-          git clone -b $LJ_BR $LJ_REPO luajit2.git && cd luajit2.git && sudo make install;
+          git clone -b $LJ_BR $LJ_REPO luajit2.git && cd luajit2.git && LJ_TAG=`git describe --abbre=0` && LUA_BIN="luajit-${LJ_TAG:1}" && sudo make install;
       fi
     - if [ "$LUA_TYPE" == "lua" ]; then
           wget "http://www.lua.org/ftp/$LUA_DIST.tar.gz" && tar xzf $LUA_DIST.tar.gz && cd $LUA_DIST && sudo make linux test install;


### PR DESCRIPTION
Manually maintaining executable name like `luajit-2.1.0-beta1 -> luajit-2.1.0-beta2` is boring, try a automated way.