### PR TITLE
Add extern C and dllexport for luaopen().

### DIFF
--- a/binding/lua53/pbc-lua53.c
+++ b/binding/lua53/pbc-lua53.c
@@ -864,6 +864,13 @@ _add_rmessage(lua_State *L) {
 	return 0;
 }
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__CODEGEARC__)
+__declspec(dllexport)
+#endif
 int
 luaopen_protobuf_c(lua_State *L) {
 	luaL_Reg reg[] = {
@@ -904,3 +911,7 @@ luaopen_protobuf_c(lua_State *L) {
 
 	return 1;
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Add extern C for luaopen_protobuf_c() in pbc-lua53.c.
Also add dllexport for Windows.