### PR TITLE
Fix writing dirty data to default table

### DIFF
--- a/binding/lua/build_ios.sh
+++ b/binding/lua/build_ios.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+#  Automatic build script for pbc-lua
+###########################################################################
+#  Change values here
+#
+SDKVERSION=$(xcrun -sdk iphoneos --show-sdk-version);
+#
+###########################################################################
+#
+# Don't change anything here
+WORKING_DIR="$(cd $(dirname $0))";
+cd "$WORKING_DIR";
+
+ARCHS="i386 x86_64 armv7 armv7s arm64";
+DEVELOPER_ROOT=$(xcode-select -print-path);
+ENABLE_PBC=0;
+
+# ======================= options ======================= 
+while getopts "a:d:hps:-" OPTION; do
+    case $OPTION in
+        a)
+            ARCHS="$OPTARG";
+        ;;
+        d)
+            DEVELOPER_ROOT="$OPTARG";
+        ;;
+        h)
+            echo "usage: $0 [options] [-- [LUADIR=Lua include directory] [other make options]]";
+            echo "options:";
+            echo "-a [archs]                    which arch need to built, multiple values must be split by space(default: $ARCHS)";
+            echo "-d [developer root directory] developer root directory, we use xcode-select -print-path to find default value.(default: $DEVELOPER_ROOT)";
+            echo "-p                            integration pbc into this lib.";
+            echo "-s [sdk version]              sdk version, we use xcrun -sdk iphoneos --show-sdk-version to find default value.(default: $SDKVERSION)";
+            echo "-h                            help message.";
+            exit 0;
+        ;;
+        p)
+            ENABLE_PBC=1;
+        ;;
+        s)
+            SDKVERSION="$SDKVERSION";
+        ;;
+        -) 
+            break;
+        ;;
+        ?)  #当有不认识的选项的时候arg为?
+            echo "unkonw argument detected";
+            exit 1;
+        ;;
+    esac
+done
+
+shift $(($OPTIND-1));
+
+echo "Ready to build for ios";
+echo "WORKING_DIR=${WORKING_DIR}";
+echo "ARCHS=${ARCHS}";
+echo "DEVELOPER_ROOT=${DEVELOPER_ROOT}";
+echo "SDKVERSION=${SDKVERSION}";
+echo "Integration pbc=${ENABLE_PBC}";
+echo "make options=$@";
+
+##########
+cp -f Makefile Makefile.bak;
+perl -p -i -e "s;\\-shared;\\-c;g" Makefile;
+perl -p -i -e "s;\\s\\-[lL][^\\s]*; ;g" Makefile;
+
+for ARCH in ${ARCHS}; do
+    echo "================== Compling $ARCH ==================";
+    if [[ "${ARCH}" == "i386" || "${ARCH}" == "x86_64" ]]; then
+        PLATFORM="iPhoneSimulator";
+    else
+        PLATFORM="iPhoneOS";
+    fi
+
+    echo "Building pbc-lua for ${PLATFORM} ${SDKVERSION} ${ARCH}" ;
+    
+    echo "Please stand by..."
+    
+    export DEVROOT="${DEVELOPER_ROOT}/Platforms/${PLATFORM}.platform/Developer";
+    export SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${SDKVERSION}.sdk";
+    export BUILD_TOOLS="${DEVELOPER_ROOT}";
+    #export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}";
+    export CC=${BUILD_TOOLS}/usr/bin/gcc;
+    #export LD=${BUILD_TOOLS}/usr/bin/ld;
+    #export CPP=${BUILD_TOOLS}/usr/bin/cpp;
+    #export CXX=${BUILD_TOOLS}/usr/bin/g++;
+    export AR=${DEVELOPER_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar;
+    #export AS=${DEVROOT}/usr/bin/as;
+    #export NM=${DEVROOT}/usr/bin/nm;
+    #export CXXCPP=${BUILD_TOOLS}/usr/bin/cpp;
+    #export RANLIB=${BUILD_TOOLS}/usr/bin/ranlib;
+    export LDFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} ";
+    export CFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} -O2 -fPIC -Wall";
+    
+    make clean TARGET=libprotobuf.a;
+    make clean TARGET=libprotobuf-$ARCH.a;
+    make libprotobuf.a CC="$CC" CFLAGS="$CFLAGS" TARGET=libprotobuf.a $@;
+    mv -f libprotobuf.a "libprotobuf-$ARCH.a";
+
+    if [ 0 -ne $ENABLE_PBC ]; then
+        ${AR} rc "libpbc-protobuf-$ARCH.a" "libprotobuf-$ARCH.a" ../../build/libpbc-${ARCH}.a ;
+    fi
+done
+mv -f Makefile.bak Makefile;
+
+cd "$WORKING_DIR";
+echo "Linking and packaging library...";
+
+LIPO_LIBS="libprotobuf";
+if [ 0 -ne $ENABLE_PBC ]; then
+    LIPO_LIBS="$LIPO_LIBS libpbc-protobuf";
+fi
+
+for LIB_NAME in $LIPO_LIBS; do
+    lipo -create $LIB_NAME-*.a -output "$LIB_NAME.a";
+    echo "$LIB_NAME.a built.";
+done

--- a/binding/lua/pbc-lua.c
+++ b/binding/lua/pbc-lua.c
@@ -20,7 +20,7 @@ extern "C" {
 
 
 #ifndef _MSC_VER
-#include <alloca.h>
+#include <stdbool.h>
 #else
 #define alloca _alloca
 #endif

--- a/binding/lua/protobuf.lua
+++ b/binding/lua/protobuf.lua
@@ -11,6 +11,7 @@ local print = print
 local io = io
 local tinsert = table.insert
 local rawget = rawget
+local rawset = rawset
 
 module "protobuf"
 
@@ -485,7 +486,18 @@ local function default_table(typename)
 		return v
 	end
 
-	v = { __index = assert(decode_message(typename , "")) }
+	local default_inst = assert(decode_message(typename , ""))
+	v = { 
+		__index = function(tb, key)
+			local ret = default_inst[key]
+			if 'table' ~= type(ret) then
+				return ret
+			end 
+			ret = setmetatable({}, { __index = ret })
+			rawset(tb, key, ret)
+			return ret
+		end
+	}
 
 	default_cache[typename]  = v
 	return v

--- a/binding/lua/testparser.lua
+++ b/binding/lua/testparser.lua
@@ -3,24 +3,55 @@ parser = require "parser"
 
 t = parser.register("addressbook.proto","../../test")
 
-addressbook = {
+local addressbook1 = {
 	name = "Alice",
 	id = 12345,
 	phone = {
 		{ number = "1301234567" },
 		{ number = "87654321", type = "WORK" },
+		{ number = "13912345678", type = "MOBILE" },
+	},
+	email = "username@domain.com"
+}
+
+local addressbook2 = {
+	name = "Bob",
+	id = 12346,
+	phone = {
+		{ number = "1301234568" },
+		{ number = "98765432", type = "HOME" },
+		{ number = "13998765432", type = "MOBILE" },
 	}
 }
 
-code = protobuf.encode("tutorial.Person", addressbook)
 
-decode = protobuf.decode("tutorial.Person" , code)
+code1 = protobuf.encode("tutorial.Person", addressbook1)
+code2 = protobuf.encode("tutorial.Person", addressbook2)
 
-print(decode.name)
-print(decode.id)
-for _,v in ipairs(decode.phone) do
-	print("\t"..v.number, v.type)
+decode1 = protobuf.decode("tutorial.Person" , code1)
+
+-- BUG [ISSUE#27](https://github.com/cloudwu/pbc/issues/27)
+decode1.profile.nick_name = "AHA"
+decode1.profile.icon = "id:1"
+
+decode2 = protobuf.decode("tutorial.Person" , code2)
+
+function print_addr(decoded)
+	print(string.format('ID: %d, Name: %s, Email: %s', decoded.id, decoded.name, tostring(decoded.email)))
+	if decoded.profile then
+		print(string.format('\tNickname: %s, Icon: %s', tostring(decoded.profile.nick_name), tostring(decoded.profile.icon)))
+	end
+	for k, v in ipairs(decoded.phone) do
+		print(string.format("\tPhone NO.%s: %16s %s", k, v.number, tostring(v.type)))
+	end
 end
+
+print_addr(decode1)
+print_addr(decode2)
 
 buffer = protobuf.pack("tutorial.Person name id", "Alice", 123)
 print(protobuf.unpack("tutorial.Person name id", buffer))
+
+code_phone = protobuf.encode("tutorial.Person.PhoneNumber", { number = "18612345678" })
+decode_phone = protobuf.decode("tutorial.Person.PhoneNumber" , code_phone)
+print(string.format("Phone: %16s %s", decode_phone.number, tostring(decode_phone.type)))

--- a/binding/lua53/build_ios.sh
+++ b/binding/lua53/build_ios.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+#  Automatic build script for pbc-lua
+#  for iPhoneOS and iPhoneSimulator
+###########################################################################
+#  Change values here
+#
+SDKVERSION=$(xcrun -sdk iphoneos --show-sdk-version);
+#
+###########################################################################
+#
+# Don't change anything here
+WORKING_DIR="$(cd $(dirname $0))";
+cd "$WORKING_DIR";
+
+ARCHS="i386 x86_64 armv7 armv7s arm64";
+DEVELOPER_ROOT=$(xcode-select -print-path);
+ENABLE_PBC=0;
+
+# ======================= options ======================= 
+while getopts "a:d:hps:-" OPTION; do
+    case $OPTION in
+        a)
+            ARCHS="$OPTARG";
+        ;;
+        d)
+            DEVELOPER_ROOT="$OPTARG";
+        ;;
+        h)
+            echo "usage: $0 [options] [-- [LUADIR=Lua include directory] [other make options]]";
+            echo "options:";
+            echo "-a [archs]                    which arch need to built, multiple values must be split by space(default: $ARCHS)";
+            echo "-d [developer root directory] developer root directory, we use xcode-select -print-path to find default value.(default: $DEVELOPER_ROOT)";
+            echo "-p                            integration pbc into this lib.";
+            echo "-s [sdk version]              sdk version, we use xcrun -sdk iphoneos --show-sdk-version to find default value.(default: $SDKVERSION)";
+            echo "-h                            help message.";
+            exit 0;
+        ;;
+        p)
+            ENABLE_PBC=1;
+        ;;
+        s)
+            SDKVERSION="$SDKVERSION";
+        ;;
+        -) 
+            break;
+        ;;
+        ?)  #当有不认识的选项的时候arg为?
+            echo "unkonw argument detected";
+            exit 1;
+        ;;
+    esac
+done
+
+shift $(($OPTIND-1));
+
+echo "Ready to build for ios";
+echo "WORKING_DIR=${WORKING_DIR}";
+echo "ARCHS=${ARCHS}";
+echo "DEVELOPER_ROOT=${DEVELOPER_ROOT}";
+echo "SDKVERSION=${SDKVERSION}";
+echo "Integration pbc=${ENABLE_PBC}";
+echo "make options=$@";
+
+##########
+cp -f Makefile Makefile.bak;
+perl -p -i -e "s;\\-shared;\\-c;g" Makefile;
+perl -p -i -e "s;\\s\\-[lL][^\\s]*; ;g" Makefile;
+
+for ARCH in ${ARCHS}; do
+    echo "================== Compling $ARCH ==================";
+    if [[ "${ARCH}" == "i386" || "${ARCH}" == "x86_64" ]]; then
+        PLATFORM="iPhoneSimulator" ;
+    else
+        PLATFORM="iPhoneOS" ;
+    fi
+
+    echo "Building pbc-lua for ${PLATFORM} ${SDKVERSION} ${ARCH}" ;
+    
+    echo "Please stand by..." ;
+    
+    export DEVROOT="${DEVELOPER_ROOT}/Platforms/${PLATFORM}.platform/Developer" ;
+    export SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${SDKVERSION}.sdk" ;
+    export BUILD_TOOLS="${DEVELOPER_ROOT}" ;
+    #export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}" ;
+    export CC=${BUILD_TOOLS}/usr/bin/gcc ;
+    #export LD=${BUILD_TOOLS}/usr/bin/ld ;
+    #export CPP=${BUILD_TOOLS}/usr/bin/cpp ;
+    #export CXX=${BUILD_TOOLS}/usr/bin/g++ ;
+    export AR=${DEVELOPER_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar;
+    #export AS=${DEVROOT}/usr/bin/as ;
+    #export NM=${DEVROOT}/usr/bin/nm ;
+    #export CXXCPP=${BUILD_TOOLS}/usr/bin/cpp ;
+    #export RANLIB=${BUILD_TOOLS}/usr/bin/ranlib ;
+    export LDFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} " ;
+    export CFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} -O2 -fPIC -Wall" ;
+   
+    make clean TARGET=libprotobuf.a;
+    make clean TARGET=libprotobuf-$ARCH.a;
+    make libprotobuf.a CC="$CC" CFLAGS="$CFLAGS" TARGET=libprotobuf.a $@;
+    mv -f libprotobuf.a "libprotobuf-$ARCH.a";
+
+    if [ 0 -ne $ENABLE_PBC ]; then
+        ${AR} rc "libpbc-protobuf-$ARCH.a" "libprotobuf-$ARCH.a" ../../build/libpbc-${ARCH}.a ;
+    fi
+done
+mv -f Makefile.bak Makefile;
+
+cd "$WORKING_DIR";
+echo "Linking and packaging library...";
+
+LIPO_LIBS="libprotobuf";
+if [ 0 -ne $ENABLE_PBC ]; then
+    LIPO_LIBS="$LIPO_LIBS libpbc-protobuf";
+fi
+
+for LIB_NAME in $LIPO_LIBS; do
+    lipo -create $LIB_NAME-*.a -output "$LIB_NAME.a";
+    echo "$LIB_NAME.a built.";
+done

--- a/binding/lua53/protobuf.lua
+++ b/binding/lua53/protobuf.lua
@@ -11,6 +11,7 @@ local print = print
 local io = io
 local tinsert = table.insert
 local rawget = rawget
+local rawset = rawset
 
 local M = {}
 
@@ -427,7 +428,18 @@ local function default_table(typename)
 		return v
 	end
 
-	v = { __index = assert(decode_message(typename , "")) }
+	local default_inst = assert(decode_message(typename , ""))
+	v = { 
+		__index = function(tb, key)
+			local ret = default_inst[key]
+			if 'table' ~= type(ret) then
+				return ret
+			end 
+			ret = setmetatable({}, { __index = ret })
+			rawset(tb, key, ret)
+			return ret
+		end
+	}
 
 	default_cache[typename]  = v
 	return v

--- a/build_ios.sh
+++ b/build_ios.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+#  Automatic build script for pbc
+###########################################################################
+#  Change values here
+#
+SDKVERSION=$(xcrun -sdk iphoneos --show-sdk-version);
+#
+###########################################################################
+#
+# Don't change anything here
+WORKING_DIR="$(cd $(dirname $0))";
+cd "$WORKING_DIR";
+
+ARCHS="i386 x86_64 armv7 armv7s arm64";
+DEVELOPER_ROOT=$(xcode-select -print-path);
+
+# ======================= options ======================= 
+while getopts "a:d:hs:-" OPTION; do
+    case $OPTION in
+        a)
+            ARCHS="$OPTARG";
+        ;;
+        d)
+            DEVELOPER_ROOT="$OPTARG";
+        ;;
+        h)
+            echo "usage: $0 [options] [-- [make options]]";
+            echo "options:";
+            echo "-a [archs]                    which arch need to built, multiple values must be split by space(default: $ARCHS)";
+            echo "-d [developer root directory] developer root directory, we use xcode-select -print-path to find default value.(default: $DEVELOPER_ROOT)";
+            echo "-s [sdk version]              sdk version, we use xcrun -sdk iphoneos --show-sdk-version to find default value.(default: $SDKVERSION)";
+            echo "-h                            help message.";
+            exit 0;
+        ;;
+        s)
+            SDKVERSION="$SDKVERSION";
+        ;;
+        -) 
+            break;
+            break;
+        ;;
+        ?)  #当有不认识的选项的时候arg为?
+            echo "unkonw argument detected";
+            exit 1;
+        ;;
+    esac
+done
+
+shift $(($OPTIND-1));
+
+echo "Ready to build for ios";
+echo "WORKING_DIR=${WORKING_DIR}";
+echo "ARCHS=${ARCHS}";
+echo "DEVELOPER_ROOT=${DEVELOPER_ROOT}";
+echo "SDKVERSION=${SDKVERSION}";
+echo "make options=$@";
+
+##########
+for ARCH in ${ARCHS}; do
+    echo "================== Compling $ARCH ==================";
+    if [[ "${ARCH}" == "i386" || "${ARCH}" == "x86_64" ]]; then
+        PLATFORM="iPhoneSimulator";
+    else
+        PLATFORM="iPhoneOS";
+    fi
+
+    if [ -e build/o ]; then
+        rm -rf build/o;
+    fi
+    echo "Building pbc for ${PLATFORM} ${SDKVERSION} ${ARCH}";
+    
+    echo "Please stand by...";
+    
+    export DEVROOT="${DEVELOPER_ROOT}/Platforms/${PLATFORM}.platform/Developer";
+    export SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${SDKVERSION}.sdk";
+    export BUILD_TOOLS="${DEVELOPER_ROOT}";
+    #export CC="${BUILD_TOOLS}/usr/bin/gcc -arch ${ARCH}";
+    export CC=${BUILD_TOOLS}/usr/bin/gcc;
+    #export LD=${BUILD_TOOLS}/usr/bin/ld;
+    #export CPP=${BUILD_TOOLS}/usr/bin/cpp;
+    #export CXX=${BUILD_TOOLS}/usr/bin/g++;
+    export AR=${DEVELOPER_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar;
+    #export AS=${DEVROOT}/usr/bin/as;
+    #export NM=${DEVROOT}/usr/bin/nm;
+    #export CXXCPP=${BUILD_TOOLS}/usr/bin/cpp;
+    #export RANLIB=${BUILD_TOOLS}/usr/bin/ranlib;
+    #export LDFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} ";
+    export CFLAGS="-arch ${ARCH} -isysroot ${SDKROOT} -O2 -fPIC -Wall";
+   
+    make libpbc.a CC="$CC" AR="$AR rc" CFLAGS="$CFLAGS" $@;
+    mv -f build/libpbc.a "build/libpbc-$ARCH.a";
+done
+
+cd "$WORKING_DIR";
+echo "Linking and packaging library...";
+
+for LIB_NAME in "libpbc"; do
+    lipo -create build/$LIB_NAME-*.a -output "build/$LIB_NAME.a";
+    echo "build/$LIB_NAME.a built.";
+done

--- a/test/addressbook.proto
+++ b/test/addressbook.proto
@@ -5,6 +5,11 @@ package tutorial;
 option java_package = "com.example.tutorial";
 option java_outer_classname = "AddressBookProtos";
 
+message Profile {
+  optional string nick_name = 1;
+  optional string icon = 2;
+}
+
 message Person {
   required string name = 1;
   required int32 id = 2;        // Unique ID number for this person.
@@ -23,6 +28,8 @@ message Person {
 
   repeated PhoneNumber phone = 4;
   repeated int32 test = 5 [packed=true];
+
+  optional Profile profile = 6;
 
   extensions 10 to max; 
 }


### PR DESCRIPTION
1. [FIX] compile error of lua 5.1 binding in MINGW
2. [FIX] changing empty decoded table will change the default table of related type

和 [ISSUE#27](https://github.com/cloudwu/pbc/issues/27) 有关
我加了一个如果解包的数据没有某个字段，会判定一次默认的table里的数据，如果类型是table会额外创建一个新table和metatable以防止写坏默认table。麻烦 @cloudwu 看看这个额外消耗是否可接受？因为如果解包的数据里有这个字段的话，只读性能是不会受到影响的（其实我觉得返回nil可能更好但是为了兼容以前的语义）

另外想了一下，这个metatable是可以缓存并且被多个默认的空实例共用的。但是这样会多一张缓存表和每次会执行查找操作，我不确定这个查找和新建一个{ __index = default_inst[key] }哪个消耗更高，所以先用了这种简单直接一些的方式。

另外，修改的 testparser.lua 的代码在**修改前**的输出是

```
$ lua5.1 testparser.lua
ID: 12345, Name: Alice, Email: username@domain.com
        Nickname: AHA, Icon: id:1
        Phone NO.1:       1301234567 HOME
        Phone NO.2:         87654321 WORK
        Phone NO.3:      13912345678 MOBILE
ID: 12346, Name: Bob, Email:
        Nickname: AHA, Icon: id:1
        Phone NO.1:       1301234568 HOME
        Phone NO.2:         98765432 HOME
        Phone NO.3:      13998765432 MOBILE
Alice   123
Phone:      18612345678 HOME
```

很明显，第二个地址簿的Profile字段不应该有内容
**修改后**的输出是

```
$ lua5.1 testparser.lua
ID: 12345, Name: Alice, Email: username@domain.com
        Nickname: AHA, Icon: id:1
        Phone NO.1:       1301234567 HOME
        Phone NO.2:         87654321 WORK
        Phone NO.3:      13912345678 MOBILE
ID: 12346, Name: Bob, Email:
        Nickname: , Icon:
        Phone NO.1:       1301234568 HOME
        Phone NO.2:         98765432 HOME
        Phone NO.3:      13998765432 MOBILE
Alice   123
Phone:      18612345678 HOME
```

我本地测试环境是MSYS2/MINGW64: lua5.1

再另外， [ISSUE#27](https://github.com/cloudwu/pbc/issues/27)的情况我手动也测试过了，不会再写脏数据了。但是没有贴上来，用testparser.lua的代码改一下也很容易构造。我就不贴了。

这个BUG导致我们客户端的判定逻辑很复杂，必须先foreach枚举key才能知道这个字段是否可用，导致非常容易遗漏然后产生其他不太容易预料的结果。

麻烦评估一下这个Fix，谢谢。
