### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -40,10 +40,14 @@ _pbcH_new(int pagesize) {
 		cap *= 2;
 	}
 	struct heap * h = (struct heap *)_pbcM_malloc(sizeof(struct heap));
-	h->current = (struct heap_page *)_pbcM_malloc(sizeof(struct heap_page) + cap);
-	h->size = cap;
-	h->used = 0;
-	h->current->next = NULL;
+	if (h) {
+		h->current = (struct heap_page *)_pbcM_malloc(sizeof(struct heap_page) + cap);
+		h->size = cap;
+		h->used = 0;
+		if (h->current) {
+			h->current->next = NULL;
+		}
+	}
 	return h;
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V522](https://www.viva64.com/en/w/v522/) There might be dereferencing of a potential null pointer 'h'. Check lines: 43, 8. alloc.c 43
[V522](https://www.viva64.com/en/w/v522/) There might be dereferencing of a potential null pointer 'h->current'. Check lines: 46, 8. alloc.c 46