### PR TITLE
bug fix

### DIFF
--- a/binding/lua53/protobuf.lua
+++ b/binding/lua53/protobuf.lua
@@ -215,7 +215,9 @@ local function encode_message(CObj, message_type, t)
 	local type = encode_type_cache[message_type]
 	for k,v in pairs(t) do
 		local func = type[k]
-		func(CObj, k , v)
+		if func then
+			func(CObj, k , v)
+		end
 	end
 end
 
@@ -305,8 +307,13 @@ local _encode_type_meta = {}
 
 function _encode_type_meta:__index(key)
 	local t, msg = c._env_type(P, self._CType, key)
-	local func = assert(_writer[t],key)(msg)
-	self[key] = func
+	-- local func = assert(_writer[t],key)(msg)
+	-- self[key] = func
+	local func = _writer[t]
+	if func then
+		func = func(msg)
+		self[key] = func
+	end
 	return func
 end
 


### PR DESCRIPTION
example:

test.lua

```lua
addressbook = {
	name = "Alice",
	id = 12345,
	phone = {
		{ number = "1301234567" },
		{ number = "87654321", type = "WORK" },
	}
}
```

root@ef956f202572:/usr/src/pbc/binding/lua53# lua test.lua
test/addressbook.proto
tutorial
Profile
        nick_name [1] LABEL_OPTIONAL
        icon [2] LABEL_OPTIONAL
Person
        name [1] LABEL_REQUIRED
        id [2] LABEL_REQUIRED
        email [3] LABEL_OPTIONAL
        phone [4] LABEL_REPEATED
        test [5] LABEL_REPEATED
        profile [6] LABEL_OPTIONAL
Ext
AddressBook
        person [1] LABEL_REPEATED
Alice
12345
        1301234567      HOME
        87654321        WORK
Alice   123     table: 0xaaaaf4c2eed0

---------------------split line-----------------------------

modify test.lua with:

```lua
addressbook = {
	name = "Alice",
	id = 12345,
	phone = {
		{ number = "1301234567" },
		{ number = "87654321", type = "WORK" },
	},
	c = 3,     -- <-i'm here
}
```

root@ef956f202572:/usr/src/pbc/binding/lua53# lua test.lua
test/addressbook.proto
tutorial
Profile
        nick_name [1] LABEL_OPTIONAL
        icon [2] LABEL_OPTIONAL
Person
        name [1] LABEL_REQUIRED
        id [2] LABEL_REQUIRED
        email [3] LABEL_OPTIONAL
        phone [4] LABEL_REPEATED
        test [5] LABEL_REPEATED
        profile [6] LABEL_OPTIONAL
Ext
AddressBook
        person [1] LABEL_REPEATED
lua: ./protobuf.lua:308: c
stack traceback:
        [C]: in function 'assert'
        ./protobuf.lua:308: in metamethod '__index'
        ./protobuf.lua:217: in upvalue 'encode_message'
        ./protobuf.lua:324: in function 'protobuf.encode'
        test.lua:35: in main chunk
        [C]: in ?